### PR TITLE
String syntax highlight fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Reach Variant Tool",
   "description": "Support for the programming language used in Reach Variant Tool.",
   "icon": "icon.png",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "license": "GPL-3.0-only",
   "author": "Unfunkable",
   "publisher": "Unfunkable",

--- a/syntaxes/rvt.tmLanguage.json
+++ b/syntaxes/rvt.tmLanguage.json
@@ -105,12 +105,12 @@
     "parameters": {
       "patterns": [
         {
-          "name": "variable.parameter.rvt",
-          "match": "(?<=[(,])[^0-9)]*(?=[,)]|\\[)"
-        },
-        {
           "name": "string.quoted.double.rvt",
           "match": "\"[^\"]*\""
+        },
+        {
+          "name": "variable.parameter.rvt",
+          "match": "(?<=[(,])[^0-9)]*(?=[,)]|\\[)"
         }
       ]
     },


### PR DESCRIPTION
Strings with numbers in them inside functions aren't highlighted differently anymore.